### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "wamr"
+description := "A standalone WebAssembly runtime with a small footprint."
+gitrepo     := "https://github.com/bytecodealliance/wasm-micro-runtime.git"
+homepage    := "https://github.com/bytecodealliance/wasm-micro-runtime/"
+license     := "Apache-2.0"
+version     := bc762fe sha256:62ac55c0109a02da1e790016f5ad3efb237fd5df96fee6bd806adbdf6b5a3fe0 https://github.com/bytecodealliance/wasm-micro-runtime/archive/bc762fe.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

