### PR TITLE
lib/lib-wamr: Move to musl and address compiler errors

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,9 +1,8 @@
 menuconfig LIBWAMR
 	bool "wamr - Intel's WebAssembly Micro Runtime"
 	default y
-	select LIBNEWLIBC
+	select LIBMUSL
 	select LIBLWIP
-	select LIBPTHREAD_EMBEDDED
 	select LIBUKTIME
 	select UKUNISTD
 	   

--- a/include/bh_platform.h
+++ b/include/bh_platform.h
@@ -26,6 +26,7 @@
 #include <time.h>
 #include <string.h>
 #include <stdio.h>
+#include <uk/essentials.h>
 
 #ifndef __cplusplus
 int snprintf(char *buffer, size_t count, const char *format, ...);
@@ -110,6 +111,8 @@ typedef int bh_socket_t;
 #ifndef NULL
 #  define NULL ((void*) 0)
 #endif
+
+#define offsetof __offsetof
 
 #define bh_assert assert
 

--- a/patches/0005-adapt-main-c-to-unikraft.patch
+++ b/patches/0005-adapt-main-c-to-unikraft.patch
@@ -74,10 +74,10 @@
 -        wasm_printf("%s\n", error_buf);
 -        goto fail4;
 +    /* load from initrd */
-+    struct ukplat_memregion_desc img;
++    struct ukplat_memregion_desc *img;
 +    if (ukplat_memregion_find_initrd0(&img) >= 0) {
-+      wasm_file_buf = (uint8*)img.base;
-+      wasm_file_size = img.len;
++      wasm_file_buf = (uint8*)img->vbase;
++      wasm_file_size = img->len;
 +      
 +      /* load WASM module */
 +      if (!(wasm_module = wasm_runtime_load(wasm_file_buf, wasm_file_size,

--- a/patches/0006-recursive_np-to-recursive.patch
+++ b/patches/0006-recursive_np-to-recursive.patch
@@ -1,0 +1,11 @@
+--- /core/shared-lib/platform/linux/bh_thread.c orig	2023-07-15 14:14:26.388776102 +0200
++++ /core/shared-lib/platform/linux/bh_thread.c	2023-07-15 14:13:17.443138319 +0200
+@@ -176,7 +176,7 @@
+     if (ret)
+         return BHT_ERROR;
+ 
+-    pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE_NP);
++    pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE);
+     ret = pthread_mutex_init(mutex, &mattr);
+     pthread_mutexattr_destroy(&mattr);
+ 


### PR DESCRIPTION
This PR addresses issues #3, #4, #6 and #7. It does this by:

* Adding a missing `offsetof` declaration to the `include/bh_platform.h` (issue #3)
* Changing the initrd0 patch in the `0005-...` patch file to work with modern unikraft (issue #4)
* Adding a new `0006-...` patch file that removes the `_NP` so that it works (issue #6)
* Moving from the newlibc to musl (issue #7)